### PR TITLE
Remove version key that prevents the file from passing desktop-file-validate

### DIFF
--- a/appimage_recipe.sh
+++ b/appimage_recipe.sh
@@ -67,7 +67,6 @@ cd ENV/$APP.AppDir/
 
 cat > $LOWERAPP.desktop <<EOF
 [Desktop Entry]
-Version=$VERSION
 Name=$APP
 Exec=$LOWERAPP
 Type=Application


### PR DESCRIPTION
`Version=` in the desktop file is not for the application version but the [XDG desktop spec](https://standards.freedesktop.org/desktop-entry-spec/latest/) version

Reference:
https://travis-ci.org/AppImage/appimage.github.io/builds/345598401#L553

This currently prevents the application from being included in the AppImageHub central directory of available AppImages.